### PR TITLE
Fixed ruby symbols to no longer italicize the colon

### DIFF
--- a/Neon.tmTheme
+++ b/Neon.tmTheme
@@ -247,6 +247,8 @@
 			<string>constant.other.symbol, constant.other.symbol punctuation.definition.constant</string>
 			<key>settings</key>
 			<dict>
+				<key>fontStyle</key>
+				<string></string>
 				<key>foreground</key>
 				<string>#FF9705</string>
 			</dict>


### PR DESCRIPTION
I just added a font style to the definition for ruby symbol that overrides the italics on punctuation.
