### PR TITLE
Generalize scopes for task tags (TODO, FIXME, etc.)

### DIFF
--- a/Neon.tmTheme
+++ b/Neon.tmTheme
@@ -545,6 +545,109 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>Table-of-Contents</string>
+			<key>scope</key>
+			<string>meta.toc-list</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#000B76</string>
+				<key>foreground</key>
+				<string>#E2FF09</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Task tag line</string>
+			<key>scope</key>
+			<string>meta.toc-list.task-tag</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9BA834</string>
+				<key>background</key>
+				<string>#000000</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Task tag line - High priority</string>
+			<key>scope</key>
+			<string>meta.toc-list.task-tag.prio-high</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#36000B</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Task tag line - Normal priority</string>
+			<key>scope</key>
+			<string>meta.toc-list.task-tag.prio-normal</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#1D2002</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Task tag line - Low priority</string>
+			<key>scope</key>
+			<string>meta.toc-list.task-tag.prio-low</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#0E2402</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Task tag</string>
+			<key>scope</key>
+			<string>entity.other.task-tag</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic bold</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Task tag - High priority</string>
+			<key>scope</key>
+			<string>keyword.other.task-tag.prio-high storage.type.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#FF112C</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Task tag - Normal priority</string>
+			<key>scope</key>
+			<string>keyword.other.task-tag.prio-normal storage.type.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#FFEB09</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Task tag - Low priority</string>
+			<key>scope</key>
+			<string>keyword.other.task-tag.prio-low storage.type.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#67E607</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>=========== JavaScript ==========</string>
 			<key>scope</key>
 			<string></string>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Neon's main goal is to make as many languages as possible look as good as possib
 * [jQuery](https://packagecontrol.io/packages/jQuery)
 * [JavaScriptNext](https://packagecontrol.io/packages/JavaScriptNext%20-%20ES6%20Syntax)
 * JSON
-* C/C++
+* C/C++, [C Improved](https://packagecontrol.io/packages/C%20Improved)
 * diff
 * HTML/XML
 * Markdown/reStructuredText


### PR DESCRIPTION
Hi,

I'm a developer of the [C Improved](https://github.com/abusalimov/SublimeCImproved) package mentioned earlier in #24, and I also use your Python Improved package (thank you, BTW :+1:).

This PR modifies the rules responsible for highlighting TODO task tags to apply to `meta.toc-list.task-tag` and `entity.other.task-tag` scopes.

First of all, `comment.line.note` does not fit very well, because at least there is a `comment.block` scope for languages that support `/* block */` comments. And a block comment can have both normal and task tag lines, and only the latter should be highlighted. That is, the highlighted part does not necessarily span the whole comment, and we need to separate a scope for that part from the comment itself.

Secondly, a task tag scoped as `comment.line.note.notation` is not actually a comment too, but rather some self-sustained entity within the outer comment.

According to the TextMate language grammar [naming conventions](https://manual.macromates.com/en/language_grammars#naming_conventions):
- > `meta` — the meta scope is generally used to markup larger parts of the document. For example the entire line which declares a function would be `meta.function` and the subsets would be `storage.type`, `entity.name.function`, `variable.parameter` etc. and only the latter would be styled.
  
  There's a widely used `meta.toc-list` scope that is primarily used to build up a list of sections in the Ctrl+R symbol list. For example, in C (both the standard Sublime package and C Improved) such scope is applied to `// === banner ===` comments and `#pragma mark section`s. A believe, TODO comment lines are worth including to the symbol index, and I decided to assign a new `meta.toc-list.task-tag` scope for that.
  
  In our case the `meta.toc-list.task-tag` scope covers the whole comment, except definition tokens, i.e. `#` or `//` sign.
- > `entity` — an entity refers to a larger part of the document, for example a chapter, class, function, or tag. We do not scope the entire entity as `entity.*` (we use `meta.*` for that). But we do use `entity.*` for the “placeholders” in the larger entity, e.g. if the entity is a chapter, we would use `entity.name.section` for the chapter title.
  
  And the `TODO` word within the meta scope suggests itself to be scoped as an entity, namely `entity.other.task-tag.todo`.

In this way, a comment containing a task tag is expected to have the following structure:

``` py
# TODO: Highlight this line.
  ^^^^---------------------------------- 'entity.other.task-tag.todo'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^-------- 'meta.toc-list.task-tag.todo'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^---- 'comment.line.number-sign'
```

Here is how it looks like when using abusalimov/SublimeCImproved#30:

![sublime-c-improved-toc-list-specialized](https://cloud.githubusercontent.com/assets/530396/11724649/45ac836e-9f86-11e5-807a-122742a45ef7.png)

Please note however, that this change currently breaks the highlighting of task tags in Python Improved. If you agree with this change, I could try to make a PR for Python Improved as well, if you want. FWIW, here's how I've implemented it: abusalimov/SublimeCImproved@0dcf851c0931c0af255cc010622b0d21022891fc

Also, I'm not a designer, so the proposed colors for new scopes may need to be revised.

Please let me know, what do you think!

/cc @xtotdam
